### PR TITLE
[chore] Update Go version to 1.25 and align GitHub Actions

### DIFF
--- a/.github/build/Makefile.core.mk
+++ b/.github/build/Makefile.core.mk
@@ -23,7 +23,7 @@ GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-coun
 REMOTE_PROVIDER="Layer5"
 
 LOCAL_PROVIDER="None"
-GOVERSION = 1.23
+GOVERSION = 1.25
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 KEYS_PATH="../../server/permissions/keys.csv"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout site
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Hugo Extended
         uses: peaceiris/actions-hugo@v3
@@ -43,7 +43,7 @@ jobs:
 
       - name: Publish to layer5 academy
         id: academy
-        uses: layer5io/academy-build@v0.1.6
+        uses: layer5io/academy-build@v0
         with:
           orgId: ${{ github.event.inputs.orgId || secrets.ACADEMY_ORG_ID }}
           token: ${{ github.event.inputs.token || secrets.ACADEMY_TOKEN }}

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Label Commenter
-        uses: peaceiris/actions-label-commenter@v1.10.0
+        uses: peaceiris/actions-label-commenter@v1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -17,7 +17,7 @@ jobs:
           echo "STARS=$(curl --silent 'https://api.github.com/repos/${{ github.repository }}' -H 'Accept: application/vnd.github.preview' | jq '.stargazers_count')" >> $GITHUB_ENV
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery-extensions/meshery-academy
 
-go 1.24.5
+go 1.25.0
 
 // Uncomment line below when testing changes to the academy theme
 // replace github.com/layer5io/academy-theme v0.1.9 => ../academy-theme


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #67

**Changes made :**

- Updates the Go version used in this repository from 1.24 to 1.25.

- Updates GitHub Action version tags across the workflows to their latest stable releases.




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 


