### PR TITLE
remove the hugo build deprecated warning

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,5 +1,7 @@
 baseURL: http://localhost:9876/academy/
 title: Example Academy
+params:
+  offlineSearch: false
 canonifyurls: true
 ignoreLogs: ['warning-goldmark-raw-html']
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #84 

before fix:
<img width="1510" height="134" alt="image" src="https://github.com/user-attachments/assets/3b2fcf87-b006-4310-9634-70e852e37a0d" />

After fix:
<img width="1492" height="218" alt="image" src="https://github.com/user-attachments/assets/f9b34ef9-b4d9-454e-8ba0-f000636f1bea" />



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
