### PR TITLE
[Chore] Upgrade Go toolchain to 1.26.4

### DIFF
--- a/.github/build/Makefile.core.mk
+++ b/.github/build/Makefile.core.mk
@@ -23,7 +23,7 @@ GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-coun
 REMOTE_PROVIDER="Layer5"
 
 LOCAL_PROVIDER="None"
-GOVERSION = 1.25
+GOVERSION = 1.26
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 KEYS_PATH="../../server/permissions/keys.csv"

--- a/.github/build/Makefile.core.mk
+++ b/.github/build/Makefile.core.mk
@@ -23,7 +23,7 @@ GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-coun
 REMOTE_PROVIDER="Layer5"
 
 LOCAL_PROVIDER="None"
-GOVERSION = 1.26
+GOVERSION = 1.26.4
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 KEYS_PATH="../../server/permissions/keys.csv"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery-extensions/meshery-academy
 
-go 1.25.0
+go 1.26.4
 
 // Uncomment line below when testing changes to the academy theme
 // replace github.com/layer5io/academy-theme v0.1.9 => ../academy-theme


### PR DESCRIPTION
## Description
Upgrade Go toolchain from 1.25 to 1.26.4 to pick up the latest security and bug fixes.

### Changes
- `go.mod`: `go 1.25.0` → `go 1.26.4`
- `.github/build/Makefile.core.mk`: `GOVERSION = 1.25` → `1.26`

Relates to meshery/meshery#19875