### PR TITLE
[CI] Add self-paced training links to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,3 +30,4 @@ assignees: ''
 #### Contributor Guide and Resources
 - 📚 [Instructions for contributing to academy-example](https://github.com/meshery-extensions/meshery-academy/blob/master/CONTRIBUTING.md)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/ci.md
+++ b/.github/ISSUE_TEMPLATE/ci.md
@@ -21,3 +21,4 @@ assignees: ''
 #### Contributor Guide and Resources
 - 📚 [Instructions for contributing to academy-example](https://github.com/meshery-extensions/meshery-academy/blob/master/CONTRIBUTING.md)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -15,3 +15,4 @@ assignees: ''
 #### Contributor Guide and Resources
 - 📚 [Instructions for contributing to academy-example](https://github.com/meshery-extensions/meshery-academy/blob/master/CONTRIBUTING.md)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -24,3 +24,4 @@ assignees: ''
 #### Contributor Guide and Resources
 - 📚 [Instructions for contributing to academy-example](https://github.com/meshery-extensions/meshery-academy/blob/master/CONTRIBUTING.md)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)


### PR DESCRIPTION
Fixes meshery-extensions/meshery-academy#154

**Notes for Reviewers**

This PR fixes #154

Added a self-paced contributor training link to the following issue templates under `.github/ISSUE_TEMPLATE/`:

- `bug_report.md`
- `ci.md`
- `documentation.md`
- `feature_request.md`

Each template now includes:
- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
