### PR TITLE
 Fix broken link to "Contributing to Models Quick Start"

### DIFF
--- a/content/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor/_index.md
+++ b/content/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor/_index.md
@@ -93,7 +93,7 @@ prerequisiteKnowledge:
     - title: "Contributing to Model Relationships"
       link: "https://docs.meshery.io/project/contributing/contributing-relationships"
     - title: "Contributing to Models Quick Start"
-      link: "https://docs.meshery.io/project/contributing/contributing-models-quick-start"
+      link: "https://docs.meshery.io/project/contributing/models/contributing-models-quick-start"
     - title: "Contributing to Meshery Policies"
       link: "https://docs.meshery.io/project/contributing/contributing-policies"
   

--- a/content/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor/meshery-models.md
+++ b/content/certifications/c5ada327-8a58-4c8a-b9fa-51b95696488c/certified-meshery-contributor/meshery-models.md
@@ -659,7 +659,7 @@ The Meshery Models examination verifies contributor understanding of one of Mesh
 
 The exam covers a variety of topics, including:
 
-- [Contributing to Models Quick Start](https://docs.meshery.io/project/contributing/contributing-models-quick-start)
+- [Contributing to Models Quick Start](https://docs.meshery.io/project/contributing/models/contributing-models-quick-start)
 - [Contributing to Meshery Models](https://docs.meshery.io/project/contributing/contributing-models)
 - [Contributing to Model Components](https://docs.meshery.io/project/contributing/contributing-components)
 - [Contributing to Model Relationships](https://docs.meshery.io/project/contributing/contributing-relationships)


### PR DESCRIPTION
This PR fixes meshery/meshery#21139

The link to "Contributing to Models Quick Start" was missing the `/models/` 
path segment, causing a 404 on docs.meshery.io.

**Broken:** https://docs.meshery.io/project/contributing/contributing-models-quick-start
**Fixed:** https://docs.meshery.io/project/contributing/models/contributing-models-quick-start

Fixed in two places:
- `_index.md` — exam prerequisite topics list
- `meshery-models.md` — exam content page

**Screen recording (local preview confirming fix):**
https://github.com/user-attachments/assets/6e39bc69-7253-4359-8d43-0e2f66c6ac1a

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Meshery Models Quick Start links to the latest contributing documentation paths.
  - Updated the “Contributing to Models Quick Start” reference for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->